### PR TITLE
custom_message_send 内使用 JSON.generate 来对消息做序列化

### DIFF
--- a/lib/wechat/api.rb
+++ b/lib/wechat/api.rb
@@ -155,7 +155,7 @@ module Wechat
     end
 
     def custom_message_send(message)
-      post 'message/custom/send', message.to_json, content_type: :json
+      post 'message/custom/send', JSON.generate(message), content_type: :json
     end
 
     def template_message_send(message)


### PR DESCRIPTION
 to_json 会将消息内部分字符做 unicode escape, 导致微信侧显示出错